### PR TITLE
KNOCKDOG-83 Fix : 안드로이드 미디어 저장 불가 이슈 픽스

### DIFF
--- a/src/shared/lib/native/saveMedia.ts
+++ b/src/shared/lib/native/saveMedia.ts
@@ -38,6 +38,7 @@ export const saveMedia = async (
     await CameraRoll.saveAsset(filePath, { type: "auto", album: mediaName });
     await RNFS.unlink(filePath);
   } else if (Platform.OS === "android") {
+    await CameraRoll.saveAsset(filePath, { type: "auto" });
     await RNFS.scanFile(filePath);
   }
 };


### PR DESCRIPTION
## 작업 내용
`saveMedia` 안드로이드 이미지 저장 코드가 누락 되어 추가함